### PR TITLE
MMM: Предлог промени од Мартин Петковски

### DIFF
--- a/bands.json
+++ b/bands.json
@@ -600,6 +600,19 @@
       "label": null
     },
     {
+      "name": "Блазеј",
+      "city": "Скопје",
+      "genre": "Рап",
+      "soundsLike": "недостигаат податоци",
+      "isActive": false,
+      "links": {
+        "spotify": "https://open.spotify.com/artist/4GnLKe6RNlgsQwC82SSWK7?si=rlZPzQbvRGCNc6jS0hOibg"
+      },
+      "contact": "недостигаат податоци",
+      "lastfmName": null,
+      "label": null
+    },
+    {
       "name": "Blla Blla Blla",
       "city": "Скопје",
       "genre": "Рок, Панк",
@@ -1239,6 +1252,19 @@
       "label": null
     },
     {
+      "name": "Дивизија",
+      "city": "недостигаат податоци",
+      "genre": "Рап",
+      "soundsLike": "недостигаат податоци",
+      "isActive": "Непознато",
+      "links": {
+        "none": "недостигаат податоци"
+      },
+      "contact": "недостигаат податоци",
+      "lastfmName": null,
+      "label": null
+    },
+    {
       "name": "Дивоградба",
       "city": "Скопје",
       "genre": "Пост-панк",
@@ -1578,6 +1604,19 @@
       "isActive": true,
       "links": {
         "spotify": "https://open.spotify.com/artist/4sQ9GomL3MFavCHI3qDw63?si=gn1MJJy2RVuXhiqb-ne-LA"
+      },
+      "contact": "недостигаат податоци",
+      "lastfmName": null,
+      "label": null
+    },
+    {
+      "name": "Фико",
+      "city": "Скопје",
+      "genre": "Рап",
+      "soundsLike": "недостигаат податоци",
+      "isActive": true,
+      "links": {
+        "spotify": "https://open.spotify.com/artist/3fh56AF8jHy6hM25hAcMoA?si=BYMUUrBdTZu5xw7qq2gwSg"
       },
       "contact": "недостигаат податоци",
       "lastfmName": null,
@@ -2011,6 +2050,19 @@
       "genre": "недостигаат податоци",
       "soundsLike": "недостигаат податоци",
       "isActive": "Непознато",
+      "links": {
+        "none": "недостигаат податоци"
+      },
+      "contact": "недостигаат податоци",
+      "lastfmName": null,
+      "label": null
+    },
+    {
+      "name": "Inserta",
+      "city": "недостигаат податоци",
+      "genre": "Рап",
+      "soundsLike": "недостигаат податоци",
+      "isActive": true,
       "links": {
         "none": "недостигаат податоци"
       },
@@ -2688,7 +2740,7 @@
       "soundsLike": "недостигаат податоци",
       "isActive": true,
       "links": {
-        "none": "недостигаат податоци"
+        "spotify": "https://open.spotify.com/artist/6PcXUcgfFMFiFpQPwOhJzj?si=5WV0MUqLRQiZF5fnwUPp4w"
       },
       "contact": "недостигаат податоци",
       "lastfmName": null,
@@ -2988,6 +3040,19 @@
       "label": null
     },
     {
+      "name": "Матеј Фолц",
+      "city": "Скопје",
+      "genre": "Рап, Трап",
+      "soundsLike": "недостигаат податоци",
+      "isActive": true,
+      "links": {
+        "spotify": "https://open.spotify.com/artist/37kyVppYsqLXJ84p4eNW2B?si=7OlJmpw5S5S6f1i_mHXf7w"
+      },
+      "contact": "недостигаат податоци",
+      "lastfmName": null,
+      "label": null
+    },
+    {
       "name": "МаЗНо, аМа Не е",
       "city": "Битола",
       "genre": "Шугејз, Пост-панк, Пост-рок",
@@ -3226,6 +3291,19 @@
       },
       "contact": "недостигаат податоци",
       "lastfmName": "Mosaique",
+      "label": null
+    },
+    {
+      "name": "Муфи",
+      "city": "Скопје",
+      "genre": "Рап",
+      "soundsLike": "недостигаат податоци",
+      "isActive": true,
+      "links": {
+        "spotify": "https://open.spotify.com/artist/4hE8n0iMqWmYyC8PG12p4j?si=djKUJZriSamJXKJbijLsyw"
+      },
+      "contact": "недостигаат податоци",
+      "lastfmName": null,
       "label": null
     },
     {
@@ -3607,6 +3685,19 @@
         "instagram": "https://www.instagram.com/peach_vice/",
         "youtube": "https://www.youtube.com/@peachvice",
         "spotify": "https://open.spotify.com/artist/1uxwv0e6ewfvnvCI2NN3Nf?si=24z-p9E4SySpL80-yt1DyQ"
+      },
+      "contact": "недостигаат податоци",
+      "lastfmName": null,
+      "label": null
+    },
+    {
+      "name": "Пецо Исток",
+      "city": "Скопје",
+      "genre": "Рап",
+      "soundsLike": "недостигаат податоци",
+      "isActive": true,
+      "links": {
+        "spotify": "https://open.spotify.com/artist/6DQhxNitPAu8YeOpNXvsR4?si=u3tLToBGRt-9Q1U3o6yzAw"
       },
       "contact": "недостигаат податоци",
       "lastfmName": null,
@@ -4101,6 +4192,19 @@
       "label": null
     },
     {
+      "name": "Шаро",
+      "city": "Скопје",
+      "genre": "Рап",
+      "soundsLike": "недостигаат податоци",
+      "isActive": true,
+      "links": {
+        "spotify": "https://open.spotify.com/artist/0Yy3eJmoJrMJDSAkMM2rWJ?si=nYAov7pNQYCuqQUBi5P5Eg"
+      },
+      "contact": "недостигаат податоци",
+      "lastfmName": null,
+      "label": null
+    },
+    {
       "name": "Sinful Glare",
       "city": "Битола",
       "genre": "недостигаат податоци",
@@ -4179,6 +4283,19 @@
       "isActive": true,
       "links": {
         "none": "недостигаат податоци"
+      },
+      "contact": "недостигаат податоци",
+      "lastfmName": null,
+      "label": null
+    },
+    {
+      "name": "Слаткаристика",
+      "city": "Скопје",
+      "genre": "Рап, Трап, Поп",
+      "soundsLike": "недостигаат податоци",
+      "isActive": true,
+      "links": {
+        "spotify": "https://open.spotify.com/artist/3C4Rcz99x3lhWNCj6MXqHu?si=pOg92wX6QSWfyUCYsmlXzw"
       },
       "contact": "недостигаат податоци",
       "lastfmName": null,
@@ -4599,6 +4716,19 @@
       "label": null
     },
     {
+      "name": "Таско",
+      "city": "Скопје",
+      "genre": "Рап, Трап, Поп",
+      "soundsLike": "недостигаат податоци",
+      "isActive": true,
+      "links": {
+        "spotify": "https://open.spotify.com/artist/73esFbI8aJdscYA5E5zpPP?si=GBt7U1lcT6CvpW3ig1nNoQ"
+      },
+      "contact": "недостигаат податоци",
+      "lastfmName": null,
+      "label": null
+    },
+    {
       "name": "Taxi Consilium",
       "city": "Скопје",
       "genre": "Фри Џез, Џез",
@@ -4802,7 +4932,7 @@
       "soundsLike": "недостигаат податоци",
       "isActive": true,
       "links": {
-        "none": "недостигаат податоци"
+        "spotify": "https://open.spotify.com/artist/49WdXLsGFNk9WrY6K3ahbQ?si=RoOdS1WYScm8zg5diLxA3A"
       },
       "contact": "недостигаат податоци",
       "lastfmName": null,
@@ -4815,7 +4945,7 @@
       "soundsLike": "недостигаат податоци",
       "isActive": "Непознато",
       "links": {
-        "none": "недостигаат податоци"
+        "spotify": "https://open.spotify.com/artist/6uTThiHy9vJ3gULgiCQf39?si=szw-O6uIQwm4DsPuQQYZQA"
       },
       "contact": "недостигаат податоци",
       "lastfmName": null,
@@ -4841,7 +4971,7 @@
       "soundsLike": "недостигаат податоци",
       "isActive": "Непознато",
       "links": {
-        "none": "недостигаат податоци"
+        "spotify": "https://open.spotify.com/artist/6tMcmHmGkT8iUT0cazSgoi?si=wsS_10pJQ3SDeEiY8SXmvg"
       },
       "contact": "недостигаат податоци",
       "lastfmName": null,
@@ -5020,6 +5150,19 @@
         "instagram": "https://www.instagram.com/vagina_corporation",
         "spotify": "https://open.spotify.com/artist/5k8NIR12dySVeJnteRqkVz",
         "youtube": "https://www.youtube.com/@vaginacorporation"
+      },
+      "contact": "недостигаат податоци",
+      "lastfmName": null,
+      "label": null
+    },
+    {
+      "name": "Вански",
+      "city": "Скопје",
+      "genre": "Рап",
+      "soundsLike": "недостигаат податоци",
+      "isActive": true,
+      "links": {
+        "spotify": "https://open.spotify.com/artist/3F4tkWeieOc9tB0bgoStbc?si=Z95KT56VRIO8tQYbEh83sQ"
       },
       "contact": "недостигаат податоци",
       "lastfmName": null,
@@ -5299,6 +5442,19 @@
       "isActive": true,
       "links": {
         "none": "недостигаат податоци"
+      },
+      "contact": "недостигаат податоци",
+      "lastfmName": null,
+      "label": null
+    },
+    {
+      "name": "Зад Аголот",
+      "city": "Скопје",
+      "genre": "Рап",
+      "soundsLike": "недостигаат податоци",
+      "isActive": true,
+      "links": {
+        "spotify": "https://open.spotify.com/artist/3lb3X5AuBfNMlbYgVmaa3y?si=i1j25YpFTke65YbtpTTFGw"
       },
       "contact": "недостигаат податоци",
       "lastfmName": null,


### PR DESCRIPTION
Предлог промени од MMM формуларот

Додадени (12): Блазеј, Дивизија, Фико, Inserta, Матеј Фолц, Муфи, Пецо Исток, Шаро, Слаткаристика, Таско, Вански, Зад Аголот
Изменети (4): LD Pistolero [links]; Toni Dimitrov [links]; Тони Китановски [links]; Тонио Сан [links]

Автоматски генерирано од MMM формуларот.
Поднесено од: Мартин Петковски