### PR TITLE
MMM: Предлог промени од јас

### DIFF
--- a/bands.json
+++ b/bands.json
@@ -18,7 +18,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "21 Век",
@@ -32,7 +33,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "21 Vek",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "2bona",
@@ -50,7 +52,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "333foenem",
@@ -67,7 +70,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "350Teric",
@@ -86,7 +90,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "500ok",
@@ -99,7 +104,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Абракадабра",
@@ -112,7 +118,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Афективен Набој",
@@ -125,7 +132,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Afektiven Naboj",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Against Them All",
@@ -139,7 +147,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Against Them All",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Agni Kai",
@@ -153,7 +162,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Александар Гулевски",
@@ -169,7 +179,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Александар Македонски",
@@ -188,7 +199,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Aleksandar Makedonski",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Александар Масевски",
@@ -201,7 +213,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Александар Ордев",
@@ -214,7 +227,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Александар Велики",
@@ -228,7 +242,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Aleksandar Veliki",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Александра Јанева",
@@ -247,7 +262,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Алембик",
@@ -264,7 +280,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "alone in a crowded room",
@@ -278,7 +295,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Amaneth",
@@ -291,7 +309,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Amaneth",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Amplidyne Effect",
@@ -306,7 +325,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Анастасија",
@@ -326,7 +346,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Anastasia",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Антониа Гиговска",
@@ -345,7 +366,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Antonia Gigovska",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Апансас",
@@ -359,7 +381,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Апореа",
@@ -373,7 +396,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Aporea",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Ареа",
@@ -392,7 +416,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Архангел",
@@ -407,7 +432,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Arhangel",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Arrested Army",
@@ -420,7 +446,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Arrested Army",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Арсов и Неговиот Најјак Бенд",
@@ -434,7 +461,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Aspirin Moon",
@@ -447,7 +475,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Астероид",
@@ -460,7 +489,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "аТа",
@@ -475,7 +505,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "B.o.r.g.",
@@ -488,7 +519,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Бадмингтонс",
@@ -502,7 +534,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Badmintons",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Багаж",
@@ -515,7 +548,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Баклава",
@@ -536,7 +570,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Baklava",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Basement Cult",
@@ -557,7 +592,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Бастион",
@@ -576,7 +612,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Bastion",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Бени и Нон Стоп",
@@ -596,7 +633,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Bernays Propaganda",
@@ -618,7 +656,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Beyond The Horizon",
@@ -632,7 +671,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Billy Esteban",
@@ -653,7 +693,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Бис-Без",
@@ -667,7 +708,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Bis-Bez",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Благојче Томевски",
@@ -680,7 +722,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Блазеј",
@@ -693,7 +736,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Blla Blla Blla",
@@ -714,7 +758,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Бодан Арсовски",
@@ -728,7 +773,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Бојана Арсовска",
@@ -746,7 +792,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Bon Praskiza",
@@ -768,7 +815,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Born For Slaughter",
@@ -783,7 +831,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Born For Slaughter",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Брејк",
@@ -797,7 +846,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Cassato",
@@ -818,7 +868,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Чалгија Саунд Систем",
@@ -837,7 +888,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "ChiefO",
@@ -850,7 +902,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Чоканче",
@@ -863,7 +916,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Cokance",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Chromatic Point",
@@ -879,7 +933,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Chromatic Point",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Цилиндар",
@@ -893,7 +948,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Cilindar",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Code 369",
@@ -908,7 +964,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Conquering Lion",
@@ -924,7 +981,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Conspiracy",
@@ -944,7 +1002,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Contact 59",
@@ -959,7 +1018,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Corrosion",
@@ -975,7 +1035,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "corrosion.",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Crystal Disco",
@@ -988,7 +1049,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Culture Development",
@@ -1008,7 +1070,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Culture Development",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Cut Your Nipple",
@@ -1022,7 +1085,8 @@
       "contact": "cutyournipple@gmail.com",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Д.Н.К",
@@ -1043,7 +1107,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Д.Н.О.",
@@ -1064,7 +1129,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Д’ Далтонс",
@@ -1078,7 +1144,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "D' Daltons",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Да Џака Накот",
@@ -1096,7 +1163,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Da Dzaka Nakot",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Damage Control",
@@ -1114,7 +1182,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Дани Димитровска",
@@ -1128,7 +1197,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Дарио и МИГ 21",
@@ -1147,7 +1217,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Дарио Панковски",
@@ -1166,7 +1237,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Дарко Димитров",
@@ -1186,7 +1258,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Давид Ангелевски",
@@ -1199,7 +1272,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Давид Темелков",
@@ -1219,7 +1293,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Deadshot",
@@ -1233,7 +1308,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Deadshot",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Decadence",
@@ -1247,7 +1323,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Decadence (MK)",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Дејан Нашоку",
@@ -1260,7 +1337,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Дејан Спасовиќ",
@@ -1273,7 +1351,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Дејание",
@@ -1286,7 +1365,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Dementor",
@@ -1299,7 +1379,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Deni Omeragich",
@@ -1312,7 +1393,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Дени те чува",
@@ -1327,7 +1409,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Denny Te Chuva",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Димиш",
@@ -1349,7 +1432,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Dimish",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Димитар Додовски",
@@ -1364,7 +1448,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Димитар Масевски",
@@ -1377,7 +1462,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Дина Јашари",
@@ -1398,7 +1484,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Dina Jashari",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Дине Донев",
@@ -1411,7 +1498,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Dionisaf",
@@ -1424,7 +1512,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Discops",
@@ -1437,7 +1526,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Дивизија",
@@ -1450,7 +1540,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Дивоградба",
@@ -1473,7 +1564,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Divogradba",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "DJ Stock Photo",
@@ -1486,7 +1578,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Dobrila & Dorian Duo",
@@ -1500,7 +1593,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Don't! Who? One.",
@@ -1513,7 +1607,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Donplaya",
@@ -1533,7 +1628,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Dorian Jovanovikj",
@@ -1546,7 +1642,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Драган Дутовски Квартет",
@@ -1567,7 +1664,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Dragan Dautovski Quartet",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Драган Ѓаконовски Шпато",
@@ -1580,7 +1678,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Драган Мијалковски",
@@ -1598,7 +1697,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Драги Иванов",
@@ -1616,7 +1716,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Druggy",
@@ -1629,7 +1730,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Dubnotic",
@@ -1642,7 +1744,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Дуке Бојаџиев",
@@ -1661,7 +1764,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Дупер",
@@ -1680,7 +1784,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "duper",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Elektro Kultura",
@@ -1693,7 +1798,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Elena Baklava",
@@ -1706,7 +1812,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Елена Ристеска",
@@ -1728,7 +1835,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Elena Risteska",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Елвир Меќиќ",
@@ -1748,7 +1856,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Ена Веко",
@@ -1761,7 +1870,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Ендемски Вид",
@@ -1781,7 +1891,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Ерзана",
@@ -1800,7 +1911,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Eye Cue",
@@ -1820,7 +1932,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Felucia",
@@ -1837,7 +1950,8 @@
       "contact": "felucia.official@gmail.com",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Fic & D'Invisibles",
@@ -1850,7 +1964,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Fiction",
@@ -1870,7 +1985,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Фико",
@@ -1889,7 +2005,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Filip Bukrshliev",
@@ -1902,7 +2019,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "FIN Project",
@@ -1915,7 +2033,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "ФК Баскет",
@@ -1932,7 +2051,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Фолтин",
@@ -1956,7 +2076,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Foltin",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Фонија",
@@ -1974,7 +2095,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Fonija",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Фосфен",
@@ -1993,7 +2115,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Fosfen",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Frontal Cortex",
@@ -2006,7 +2129,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Fundament",
@@ -2019,7 +2143,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Funk Shui",
@@ -2039,7 +2164,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Furion",
@@ -2053,7 +2179,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Furion",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "fydhws",
@@ -2066,7 +2193,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Galoski",
@@ -2091,7 +2219,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Galoski",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Garameth",
@@ -2105,7 +2234,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Gargoyles",
@@ -2119,7 +2249,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Gargoyles",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Ѓокица Зафировски",
@@ -2132,7 +2263,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Ѓоко Ѓорчев",
@@ -2145,7 +2277,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Ѓоко Таневски",
@@ -2158,7 +2291,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Ѓорѓи Крстевски",
@@ -2171,7 +2305,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Gligor Kondovski",
@@ -2184,7 +2319,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Големата Вода",
@@ -2201,7 +2337,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "GORA$T",
@@ -2217,7 +2354,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Горан Трајкоски",
@@ -2235,7 +2373,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Goreiju",
@@ -2256,7 +2395,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Green Grass Dreams",
@@ -2269,7 +2409,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Green Out",
@@ -2287,7 +2428,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Green Out",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "GURUVOODOO",
@@ -2300,7 +2442,11 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": [
+        "#ffa502",
+        "#2d1d00"
+      ],
+      "confirmed": true
     },
     {
       "name": "GWASS",
@@ -2317,7 +2463,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Хаос Ин Лаос",
@@ -2330,7 +2477,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Hardfaced",
@@ -2343,7 +2491,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Herzel",
@@ -2364,7 +2513,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "In Fuse",
@@ -2377,7 +2527,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Inserta",
@@ -2390,7 +2541,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Iron Fang",
@@ -2404,7 +2556,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Iron Fang",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Искра",
@@ -2421,7 +2574,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Искра Трпева",
@@ -2434,7 +2588,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "ИВЛ",
@@ -2447,7 +2602,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Јана Бурческа",
@@ -2467,7 +2623,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Jana Burčeska",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Jeff Bahami",
@@ -2481,7 +2638,11 @@
       "contact": "martin@najjak.com",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": [
+        "#922fff",
+        "#ff0202"
+      ],
+      "confirmed": true
     },
     {
       "name": "Johnny Larry",
@@ -2500,7 +2661,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Јован Јованов",
@@ -2520,7 +2682,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Јован Милошевски",
@@ -2533,7 +2696,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Јулија",
@@ -2546,7 +2710,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Кактус",
@@ -2559,7 +2724,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Kala",
@@ -2572,7 +2738,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "КАЛБУЛА",
@@ -2588,7 +2755,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Калдрма",
@@ -2601,7 +2769,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Калико",
@@ -2622,7 +2791,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Калиопи",
@@ -2645,7 +2815,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Kaliopi",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Карамела",
@@ -2658,7 +2829,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Карла Левински",
@@ -2671,7 +2843,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Karma Scale",
@@ -2691,7 +2864,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Каролина Гочева",
@@ -2712,7 +2886,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Kazan",
@@ -2725,7 +2900,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "КЕМ",
@@ -2745,7 +2921,11 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": [
+        "#402020",
+        "#604020"
+      ],
+      "confirmed": true
     },
     {
       "name": "Кенопсија",
@@ -2760,7 +2940,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Kenopsija",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Кентаур",
@@ -2773,7 +2954,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Kepurdhat",
@@ -2789,7 +2971,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Kiborg",
@@ -2802,7 +2985,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Кирил Џајковски",
@@ -2822,7 +3006,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Kismet",
@@ -2835,7 +3020,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Клержо",
@@ -2848,7 +3034,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Климе Ковачески",
@@ -2861,7 +3048,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Кочани Оркестар",
@@ -2883,7 +3071,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Kocani Orkestar",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Кокиче",
@@ -2897,7 +3086,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Конкорд",
@@ -2918,7 +3108,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Корка",
@@ -2937,7 +3128,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Korka",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Kostadin Delinikolov",
@@ -2950,7 +3142,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Крсто Роџевски",
@@ -2968,7 +3161,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Kristo Rodzevski",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Куку Леле",
@@ -2981,7 +3175,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Културно Уметнички Работници",
@@ -3002,7 +3197,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Kulturno Umetnicki Rabotnici",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "KungFoolish",
@@ -3015,7 +3211,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Ламбе Алабаковски",
@@ -3032,7 +3229,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Land",
@@ -3045,7 +3243,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Лара Иванова",
@@ -3065,7 +3264,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Лас Веѓас",
@@ -3082,7 +3282,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Last Act Of Defiance",
@@ -3096,7 +3297,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Last Act Of Defiance",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Last Expedition",
@@ -3110,7 +3312,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Last Expedition",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Ластовица",
@@ -3123,7 +3326,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Лазар Дарковски",
@@ -3137,7 +3341,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Лазар Нелковски",
@@ -3151,7 +3356,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "LD Pistolero",
@@ -3166,7 +3372,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Леб и Сол",
@@ -3190,7 +3397,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Leb i Sol",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Lefterna",
@@ -3203,7 +3411,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Легијата",
@@ -3224,7 +3433,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Legijata",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Лева Патика",
@@ -3237,7 +3447,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Љубојна",
@@ -3250,7 +3461,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Lola V. Stein",
@@ -3263,7 +3475,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Лозано",
@@ -3284,7 +3497,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Lucent",
@@ -3299,7 +3513,8 @@
       "contact": "bandlucent@gmail.com",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Lufthansa",
@@ -3317,7 +3532,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Маја Панчева",
@@ -3330,7 +3546,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Маја Саздановска",
@@ -3347,7 +3564,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Маја Вукичевиќ",
@@ -3364,7 +3582,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Maki Hachiya",
@@ -3377,7 +3596,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Mallard",
@@ -3391,7 +3611,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Mамут",
@@ -3411,7 +3632,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "MANAS",
@@ -3426,7 +3648,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Мариналеда",
@@ -3440,7 +3663,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Mark Purpose",
@@ -3458,7 +3682,8 @@
       "contact": "markpurpose79@gmail.com",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Мартин Џорлев",
@@ -3471,7 +3696,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Мартин Ѓаконовски",
@@ -3484,7 +3710,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Martix",
@@ -3497,7 +3724,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Матеј Фолц",
@@ -3517,7 +3745,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "МаЗНо, аМа Не е",
@@ -3532,7 +3761,11 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Ma3Ho, aMa He e",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": [
+        "#2f73ff",
+        "#ffffff"
+      ],
+      "confirmed": true
     },
     {
       "name": "Медуза",
@@ -3545,7 +3778,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Melissa",
@@ -3559,7 +3793,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Меморија",
@@ -3580,7 +3815,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Memorija",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "МЕНКА",
@@ -3593,7 +3829,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Mev",
@@ -3606,7 +3843,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Миа Перевска",
@@ -3623,7 +3861,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Mila and the Heartbreakers",
@@ -3636,7 +3875,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": "Издвојуваме",
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Милица Ризо",
@@ -3650,7 +3890,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Mindless Violence",
@@ -3666,7 +3907,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Mindless Violence",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Misanthrope",
@@ -3679,7 +3921,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Мизар",
@@ -3701,7 +3944,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Mizar",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Mnemonic45",
@@ -3714,7 +3958,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Moira",
@@ -3732,7 +3977,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Molokai",
@@ -3747,7 +3993,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Molokai",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Морал",
@@ -3760,7 +4007,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Mosaique",
@@ -3773,7 +4021,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Mosaique",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Муфи",
@@ -3792,7 +4041,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Мугер Фугер",
@@ -3805,7 +4055,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Музак",
@@ -3818,7 +4069,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "My Tear",
@@ -3831,7 +4083,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Nascor San",
@@ -3844,7 +4097,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Наско",
@@ -3858,7 +4112,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Небо",
@@ -3871,7 +4126,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Нема лабаво",
@@ -3884,7 +4140,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "New Police State",
@@ -3897,7 +4154,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Next Time",
@@ -3920,7 +4178,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Next Time",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Nickarth",
@@ -3933,7 +4192,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Ние Запирка Другарите",
@@ -3946,7 +4206,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Никеја",
@@ -3959,7 +4220,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Николче Мицевски",
@@ -3972,7 +4234,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Ninoslav Spirovski",
@@ -3985,7 +4248,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Нискоградба",
@@ -3998,7 +4262,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "No Name Nation",
@@ -4017,7 +4282,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "No Name Nation",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Нокаут",
@@ -4037,7 +4303,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Nokaut",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Nora",
@@ -4050,7 +4317,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Новиот Почеток",
@@ -4071,7 +4339,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Noviot Pochetok",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Новоградска",
@@ -4084,7 +4353,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Нулта Позитив",
@@ -4104,7 +4374,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Nulta Pozitiv",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Огнен Здравковски",
@@ -4118,7 +4389,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Ognen Zdravkovski",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Оливер Димитров",
@@ -4131,7 +4403,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Орион",
@@ -4146,7 +4419,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Пајак",
@@ -4168,7 +4442,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Паркети",
@@ -4182,7 +4457,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Parketi",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Павел Ренџов",
@@ -4195,7 +4471,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Peach Vice",
@@ -4212,7 +4489,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Пецо Исток",
@@ -4228,7 +4506,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Педро Хоризонте",
@@ -4241,7 +4520,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Пијан Славеј",
@@ -4260,7 +4540,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Pijan Slavej",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Пики",
@@ -4273,7 +4554,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Pikolomini",
@@ -4286,7 +4568,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Плава",
@@ -4300,7 +4583,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Pluto's Doubts",
@@ -4319,7 +4603,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "ПМГ Колектив",
@@ -4340,7 +4625,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "PMG Kolektiv",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Poetronika",
@@ -4353,7 +4639,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Пресен Зрак",
@@ -4367,7 +4654,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Presen Zrak",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Prince$$ Donatsu",
@@ -4388,7 +4676,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Project Zlust",
@@ -4407,7 +4696,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Project Zlust",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Промашена Инвестиција",
@@ -4421,7 +4711,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Raven",
@@ -4435,7 +4726,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Raven",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Ребека",
@@ -4448,7 +4740,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Red 18",
@@ -4463,7 +4756,8 @@
       "contact": "red18band@gmail.com",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Red Sails Below",
@@ -4476,7 +4770,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Ристо Бомбата",
@@ -4490,7 +4785,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Risto Bombata",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Ристо Самарџиев",
@@ -4509,7 +4805,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Роберт Билбилов",
@@ -4530,7 +4827,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Роботек",
@@ -4549,7 +4847,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Royal Albert Hall",
@@ -4563,7 +4862,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Royal Albert Hall",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Ruda Vega",
@@ -4583,7 +4883,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Ruda Vega",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Ruststained",
@@ -4604,7 +4905,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "С.А.М.",
@@ -4617,7 +4919,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Saidon",
@@ -4630,7 +4933,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Санаториум",
@@ -4645,7 +4949,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Sanatorium",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Сарацени",
@@ -4658,7 +4963,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Сашка Петковска",
@@ -4671,7 +4977,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Sasho Uzun",
@@ -4684,7 +4991,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Saso Popovski Trio",
@@ -4706,7 +5014,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Saso Recyd",
@@ -4719,7 +5028,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Satanhord",
@@ -4732,7 +5042,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Scattered",
@@ -4745,7 +5056,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Schoiroideairis",
@@ -4758,7 +5070,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Serpentine Fire",
@@ -4772,7 +5085,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Serpentine Fire",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Шаро",
@@ -4792,7 +5106,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Sinful Glare",
@@ -4811,7 +5126,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Siniac",
@@ -4825,7 +5141,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Siniac",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Синтезис",
@@ -4846,7 +5163,11 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Sintezis",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": [
+        "#2f49ff",
+        "#ffffff"
+      ],
+      "confirmed": false
     },
     {
       "name": "Sioto Jazz",
@@ -4865,7 +5186,11 @@
       "contact": "siotojazz@gmail.com",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": "https://siotojazz.com/extra/photos/SJ_12.JPG"
+      "accentColors": [
+        "#c80401",
+        "#9b0000"
+      ],
+      "confirmed": true
     },
     {
       "name": "SIZ",
@@ -4878,7 +5203,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Skrit",
@@ -4891,7 +5217,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Слаткаристика",
@@ -4913,7 +5240,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Slavco Kocev",
@@ -4926,7 +5254,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Славе Димитров",
@@ -4942,7 +5271,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Smoke Shakers",
@@ -4958,7 +5288,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Smoke Shakers",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Смут",
@@ -4978,7 +5309,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Smut",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Soulmental",
@@ -4991,7 +5323,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Sound Waves",
@@ -5005,7 +5338,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Sound_00",
@@ -5018,7 +5352,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Spank",
@@ -5032,7 +5367,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "SPECTRAL NERVE",
@@ -5045,7 +5381,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Steel Temple",
@@ -5058,7 +5395,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Steel Thunder",
@@ -5071,7 +5409,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Steel Thunder",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Stefan Petanovski",
@@ -5084,7 +5423,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Стих Наумов",
@@ -5097,7 +5437,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Стиховен Калибар",
@@ -5110,7 +5451,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Стој, После!",
@@ -5127,7 +5469,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Stoj, Posle!",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Страјк",
@@ -5145,7 +5488,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "String Forces",
@@ -5165,7 +5509,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Студени Нозе",
@@ -5178,7 +5523,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Suns",
@@ -5192,7 +5538,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Suns",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Sunset Cruise",
@@ -5205,7 +5552,11 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Sunset Cruise",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": [
+        "#001e26",
+        "#0267ff"
+      ],
+      "confirmed": true
     },
     {
       "name": "Супер Нова",
@@ -5219,7 +5570,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Super Nova",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Суперхикс",
@@ -5242,7 +5594,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Superhiks",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Svirci Vardarci",
@@ -5255,7 +5608,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Sweet Rapscalions",
@@ -5270,7 +5624,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Syned Brain",
@@ -5283,7 +5638,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Т.Б. Трачери",
@@ -5296,7 +5652,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "TA$AK",
@@ -5313,7 +5670,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Тамара Стојковска",
@@ -5328,7 +5686,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Тамара Тодевска",
@@ -5350,7 +5709,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Tamara Todevska",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Тања Царовска",
@@ -5363,7 +5723,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Таско",
@@ -5384,7 +5745,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Taxi Consilium",
@@ -5401,7 +5763,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Телемама",
@@ -5416,7 +5779,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Telemama",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Тело Наука Совршена",
@@ -5430,7 +5794,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Telonauka Sovrsena",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Темпера",
@@ -5444,7 +5809,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Tempera",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "The Government",
@@ -5459,7 +5825,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "The Hip",
@@ -5472,7 +5839,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "The Hounds",
@@ -5487,7 +5855,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "The John",
@@ -5502,7 +5871,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "The Ooz",
@@ -5515,7 +5885,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "The Protagonist",
@@ -5528,7 +5899,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "The Protagonist",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "The Wise Shouldn't Stay Quiet",
@@ -5542,7 +5914,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "This Home Is Prepared",
@@ -5556,7 +5929,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "This Home Is Prepared",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "this would save us",
@@ -5569,7 +5943,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Three Minutes in the Rain",
@@ -5582,7 +5957,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Toni Dimitrov",
@@ -5597,7 +5973,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Тони Китановски",
@@ -5614,7 +5991,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Тони Зен",
@@ -5635,7 +6013,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Toni Zen",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Тонио Сан",
@@ -5652,7 +6031,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Tonyo San",
@@ -5669,7 +6049,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Тоше Проески",
@@ -5691,7 +6072,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Trapostol",
@@ -5704,7 +6086,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Trendkill",
@@ -5721,7 +6104,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Трето Колено",
@@ -5734,7 +6118,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Трипнотик",
@@ -5747,7 +6132,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Trold",
@@ -5760,7 +6146,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Tsar Von Time",
@@ -5777,7 +6164,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Two Sides",
@@ -5791,7 +6179,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Two Sides",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Überzeitung",
@@ -5804,7 +6193,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Убиј Дедо",
@@ -5817,7 +6207,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Угро",
@@ -5830,7 +6221,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Vagina Corporation",
@@ -5850,7 +6242,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Вански",
@@ -5868,7 +6261,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Vehementor",
@@ -5882,7 +6276,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "ВЕЛ",
@@ -5903,7 +6298,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "В Е Л",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Венко Серафимов",
@@ -5916,7 +6312,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Верица Пандиловска",
@@ -5935,7 +6332,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Верка",
@@ -5953,7 +6351,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Verka",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Викторија Лоба",
@@ -5970,7 +6369,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Визија",
@@ -5986,7 +6386,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Vizija",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Владо Јаневски",
@@ -6004,7 +6405,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Влатко Стефановски",
@@ -6025,7 +6427,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": "Vlatko Stefanovski",
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Водолија",
@@ -6038,7 +6441,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Врчак",
@@ -6057,7 +6461,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Warm Hands",
@@ -6070,7 +6475,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Will Discuss",
@@ -6083,7 +6489,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Xajka",
@@ -6102,7 +6509,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "XARAKIRI",
@@ -6124,7 +6532,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Xavier Acid",
@@ -6137,7 +6546,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "XXL",
@@ -6156,7 +6566,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Yordan Kostov",
@@ -6170,7 +6581,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Young Dadi",
@@ -6191,7 +6603,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Yudhisthira",
@@ -6204,7 +6617,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Зад Аголот",
@@ -6224,7 +6638,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Zanadu",
@@ -6243,7 +6658,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Зарина Првасевда",
@@ -6263,7 +6679,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "ZEE",
@@ -6279,7 +6696,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Zhabata",
@@ -6292,7 +6710,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Животни",
@@ -6307,7 +6726,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Зијан",
@@ -6320,7 +6740,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     },
     {
       "name": "Zol Jad",
@@ -6333,7 +6754,8 @@
       "contact": "недостигаат податоци",
       "lastfmName": null,
       "label": null,
-      "backgroundMedia": null
+      "accentColors": null,
+      "confirmed": false
     }
   ]
 }


### PR DESCRIPTION
Предлог промени од MMM формуларот

Изменети (401): 100REN [confirmed, accentColors]; 21 Век [confirmed, accentColors]; 2bona [confirmed, accentColors]; 333foenem [confirmed, accentColors]; 350Teric [confirmed, accentColors]; 500ok [confirmed, accentColors]; Абракадабра [confirmed, accentColors]; Афективен Набој [confirmed, accentColors]; Against Them All [confirmed, accentColors]; Agni Kai [confirmed, accentColors]; Александар Гулевски [confirmed, accentColors]; Александар Македонски [confirmed, accentColors]; Александар Масевски [confirmed, accentColors]; Александар Ордев [confirmed, accentColors]; Александар Велики [confirmed, accentColors]; Александра Јанева [confirmed, accentColors]; Алембик [confirmed, accentColors]; alone in a crowded room [confirmed, accentColors]; Amaneth [confirmed, accentColors]; Amplidyne Effect [confirmed, accentColors]; Анастасија [confirmed, accentColors]; Антониа Гиговска [confirmed, accentColors]; Апансас [confirmed, accentColors]; Апореа [confirmed, accentColors]; Ареа [confirmed, accentColors]; Архангел [confirmed, accentColors]; Arrested Army [confirmed, accentColors]; Арсов и Неговиот Најјак Бенд [confirmed, accentColors]; Aspirin Moon [confirmed, accentColors]; Астероид [confirmed, accentColors]; аТа [confirmed, accentColors]; B.o.r.g. [confirmed, accentColors]; Бадмингтонс [confirmed, accentColors]; Багаж [confirmed, accentColors]; Баклава [confirmed, accentColors]; Basement Cult [confirmed, accentColors]; Бастион [confirmed, accentColors]; Бени и Нон Стоп [confirmed, accentColors]; Bernays Propaganda [confirmed, accentColors]; Beyond The Horizon [confirmed, accentColors]; Billy Esteban [confirmed, accentColors]; Бис-Без [confirmed, accentColors]; Благојче Томевски [confirmed, accentColors]; Блазеј [confirmed, accentColors]; Blla Blla Blla [confirmed, accentColors]; Бодан Арсовски [confirmed, accentColors]; Бојана Арсовска [confirmed, accentColors]; Bon Praskiza [confirmed, accentColors]; Born For Slaughter [confirmed, accentColors]; Брејк [confirmed, accentColors]; Cassato [confirmed, accentColors]; Чалгија Саунд Систем [confirmed, accentColors]; ChiefO [confirmed, accentColors]; Чоканче [confirmed, accentColors]; Chromatic Point [confirmed, accentColors]; Цилиндар [confirmed, accentColors]; Code 369 [confirmed, accentColors]; Conquering Lion [confirmed, accentColors]; Conspiracy [confirmed, accentColors]; Contact 59 [confirmed, accentColors]; Corrosion [confirmed, accentColors]; Crystal Disco [confirmed, accentColors]; Culture Development [confirmed, accentColors]; Cut Your Nipple [confirmed, accentColors]; Д.Н.К [confirmed, accentColors]; Д.Н.О. [confirmed, accentColors]; Д’ Далтонс [confirmed, accentColors]; Да Џака Накот [confirmed, accentColors]; Damage Control [confirmed, accentColors]; Дани Димитровска [confirmed, accentColors]; Дарио и МИГ 21 [confirmed, accentColors]; Дарио Панковски [confirmed, accentColors]; Дарко Димитров [confirmed, accentColors]; Давид Ангелевски [confirmed, accentColors]; Давид Темелков [confirmed, accentColors]; Deadshot [confirmed, accentColors]; Decadence [confirmed, accentColors]; Дејан Нашоку [confirmed, accentColors]; Дејан Спасовиќ [confirmed, accentColors]; Дејание [confirmed, accentColors]; Dementor [confirmed, accentColors]; Deni Omeragich [confirmed, accentColors]; Дени те чува [confirmed, accentColors]; Димиш [confirmed, accentColors]; Димитар Додовски [confirmed, accentColors]; Димитар Масевски [confirmed, accentColors]; Дина Јашари [confirmed, accentColors]; Дине Донев [confirmed, accentColors]; Dionisaf [confirmed, accentColors]; Discops [confirmed, accentColors]; Дивизија [confirmed, accentColors]; Дивоградба [confirmed, accentColors]; DJ Stock Photo [confirmed, accentColors]; Dobrila & Dorian Duo [confirmed, accentColors]; Don't! Who? One. [confirmed, accentColors]; Donplaya [confirmed, accentColors]; Dorian Jovanovikj [confirmed, accentColors]; Драган Дутовски Квартет [confirmed, accentColors]; Драган Ѓаконовски Шпато [confirmed, accentColors]; Драган Мијалковски [confirmed, accentColors]; Драги Иванов [confirmed, accentColors]; Druggy [confirmed, accentColors]; Dubnotic [confirmed, accentColors]; Дуке Бојаџиев [confirmed, accentColors]; Дупер [confirmed, accentColors]; Elektro Kultura [confirmed, accentColors]; Elena Baklava [confirmed, accentColors]; Елена Ристеска [confirmed, accentColors]; Елвир Меќиќ [confirmed, accentColors]; Ена Веко [confirmed, accentColors]; Ендемски Вид [confirmed, accentColors]; Ерзана [confirmed, accentColors]; Eye Cue [confirmed, accentColors]; Felucia [confirmed, accentColors]; Fic & D'Invisibles [confirmed, accentColors]; Fiction [confirmed, accentColors]; Фико [confirmed, accentColors]; Filip Bukrshliev [confirmed, accentColors]; FIN Project [confirmed, accentColors]; ФК Баскет [confirmed, accentColors]; Фолтин [confirmed, accentColors]; Фонија [confirmed, accentColors]; Фосфен [confirmed, accentColors]; Frontal Cortex [confirmed, accentColors]; Fundament [confirmed, accentColors]; Funk Shui [confirmed, accentColors]; Furion [confirmed, accentColors]; fydhws [confirmed, accentColors]; Galoski [confirmed, accentColors]; Garameth [confirmed, accentColors]; Gargoyles [confirmed, accentColors]; Ѓокица Зафировски [confirmed, accentColors]; Ѓоко Ѓорчев [confirmed, accentColors]; Ѓоко Таневски [confirmed, accentColors]; Ѓорѓи Крстевски [confirmed, accentColors]; Gligor Kondovski [confirmed, accentColors]; Големата Вода [confirmed, accentColors]; GORAT [confirmed, accentColors]; Горан Трајкоски [confirmed, accentColors]; Goreiju [confirmed, accentColors]; Green Grass Dreams [confirmed, accentColors]; Green Out [confirmed, accentColors]; GURUVOODOO [confirmed, accentColors]; GWASS [confirmed, accentColors]; Хаос Ин Лаос [confirmed, accentColors]; Hardfaced [confirmed, accentColors]; Herzel [confirmed, accentColors]; In Fuse [confirmed, accentColors]; Inserta [confirmed, accentColors]; Iron Fang [confirmed, accentColors]; Искра [confirmed, accentColors]; Искра Трпева [confirmed, accentColors]; ИВЛ [confirmed, accentColors]; Јана Бурческа [confirmed, accentColors]; Jeff Bahami [confirmed, accentColors]; Johnny Larry [confirmed, accentColors]; Јован Јованов [confirmed, accentColors]; Јован Милошевски [confirmed, accentColors]; Јулија [confirmed, accentColors]; Кактус [confirmed, accentColors]; Kala [confirmed, accentColors]; КАЛБУЛА [confirmed, accentColors]; Калдрма [confirmed, accentColors]; Калико [confirmed, accentColors]; Калиопи [confirmed, accentColors]; Карамела [confirmed, accentColors]; Карла Левински [confirmed, accentColors]; Karma Scale [confirmed, accentColors]; Каролина Гочева [confirmed, accentColors]; Kazan [confirmed, accentColors]; КЕМ [confirmed, accentColors]; Кенопсија [confirmed, accentColors]; Кентаур [confirmed, accentColors]; Kepurdhat [confirmed, accentColors]; Kiborg [confirmed, accentColors]; Кирил Џајковски [confirmed, accentColors]; Kismet [confirmed, accentColors]; Клержо [confirmed, accentColors]; Климе Ковачески [confirmed, accentColors]; Кочани Оркестар [confirmed, accentColors]; Кокиче [confirmed, accentColors]; Конкорд [confirmed, accentColors]; Корка [confirmed, accentColors]; Kostadin Delinikolov [confirmed, accentColors]; Крсто Роџевски [confirmed, accentColors]; Куку Леле [confirmed, accentColors]; Културно Уметнички Работници [confirmed, accentColors]; KungFoolish [confirmed, accentColors]; Ламбе Алабаковски [confirmed, accentColors]; Land [confirmed, accentColors]; Лара Иванова [confirmed, accentColors]; Лас Веѓас [confirmed, accentColors]; Last Act Of Defiance [confirmed, accentColors]; Last Expedition [confirmed, accentColors]; Ластовица [confirmed, accentColors]; Лазар Дарковски [confirmed, accentColors]; Лазар Нелковски [confirmed, accentColors]; LD Pistolero [confirmed, accentColors]; Леб и Сол [confirmed, accentColors]; Lefterna [confirmed, accentColors]; Легијата [confirmed, accentColors]; Лева Патика [confirmed, accentColors]; Љубојна [confirmed, accentColors]; Lola V. Stein [confirmed, accentColors]; Лозано [confirmed, accentColors]; Lucent [confirmed, accentColors]; Lufthansa [confirmed, accentColors]; Маја Панчева [confirmed, accentColors]; Маја Саздановска [confirmed, accentColors]; Маја Вукичевиќ [confirmed, accentColors]; Maki Hachiya [confirmed, accentColors]; Mallard [confirmed, accentColors]; Mамут [confirmed, accentColors]; MANAS [confirmed, accentColors]; Мариналеда [confirmed, accentColors]; Mark Purpose [confirmed, accentColors]; Мартин Џорлев [confirmed, accentColors]; Мартин Ѓаконовски [confirmed, accentColors]; Martix [confirmed, accentColors]; Матеј Фолц [confirmed, accentColors]; МаЗНо, аМа Не е [confirmed, accentColors]; Медуза [confirmed, accentColors]; Melissa [confirmed, accentColors]; Меморија [confirmed, accentColors]; МЕНКА [confirmed, accentColors]; Mev [confirmed, accentColors]; Миа Перевска [confirmed, accentColors]; Mila and the Heartbreakers [confirmed, accentColors]; Милица Ризо [confirmed, accentColors]; Mindless Violence [confirmed, accentColors]; Misanthrope [confirmed, accentColors]; Мизар [confirmed, accentColors]; Mnemonic45 [confirmed, accentColors]; Moira [confirmed, accentColors]; Molokai [confirmed, accentColors]; Морал [confirmed, accentColors]; Mosaique [confirmed, accentColors]; Муфи [confirmed, accentColors]; Мугер Фугер [confirmed, accentColors]; Музак [confirmed, accentColors]; My Tear [confirmed, accentColors]; Nascor San [confirmed, accentColors]; Наско [confirmed, accentColors]; Небо [confirmed, accentColors]; Нема лабаво [confirmed, accentColors]; New Police State [confirmed, accentColors]; Next Time [confirmed, accentColors]; Nickarth [confirmed, accentColors]; Ние Запирка Другарите [confirmed, accentColors]; Никеја [confirmed, accentColors]; Николче Мицевски [confirmed, accentColors]; Ninoslav Spirovski [confirmed, accentColors]; Нискоградба [confirmed, accentColors]; No Name Nation [confirmed, accentColors]; Нокаут [confirmed, accentColors]; Nora [confirmed, accentColors]; Новиот Почеток [confirmed, accentColors]; Новоградска [confirmed, accentColors]; Нулта Позитив [confirmed, accentColors]; Огнен Здравковски [confirmed, accentColors]; Оливер Димитров [confirmed, accentColors]; Орион [confirmed, accentColors]; Пајак [confirmed, accentColors]; Паркети [confirmed, accentColors]; Павел Ренџов [confirmed, accentColors]; Peach Vice [confirmed, accentColors]; Пецо Исток [confirmed, accentColors]; Педро Хоризонте [confirmed, accentColors]; Пијан Славеј [confirmed, accentColors]; Пики [confirmed, accentColors]; Pikolomini [confirmed, accentColors]; Плава [confirmed, accentColors]; Pluto's Doubts [confirmed, accentColors]; ПМГ Колектив [confirmed, accentColors]; Poetronika [confirmed, accentColors]; Пресен Зрак [confirmed, accentColors]; Prince$$ Donatsu [confirmed, accentColors]; Project Zlust [confirmed, accentColors]; Промашена Инвестиција [confirmed, accentColors]; Raven [confirmed, accentColors]; Ребека [confirmed, accentColors]; Red 18 [confirmed, accentColors]; Red Sails Below [confirmed, accentColors]; Ристо Бомбата [confirmed, accentColors]; Ристо Самарџиев [confirmed, accentColors]; Роберт Билбилов [confirmed, accentColors]; Роботек [confirmed, accentColors]; Royal Albert Hall [confirmed, accentColors]; Ruda Vega [confirmed, accentColors]; Ruststained [confirmed, accentColors]; С.А.М. [confirmed, accentColors]; Saidon [confirmed, accentColors]; Санаториум [confirmed, accentColors]; Сарацени [confirmed, accentColors]; Сашка Петковска [confirmed, accentColors]; Sasho Uzun [confirmed, accentColors]; Saso Popovski Trio [confirmed, accentColors]; Saso Recyd [confirmed, accentColors]; Satanhord [confirmed, accentColors]; Scattered [confirmed, accentColors]; Schoiroideairis [confirmed, accentColors]; Serpentine Fire [confirmed, accentColors]; Шаро [confirmed, accentColors]; Sinful Glare [confirmed, accentColors]; Siniac [confirmed, accentColors]; Синтезис [confirmed, accentColors]; Sioto Jazz [confirmed, accentColors]; SIZ [confirmed, accentColors]; Skrit [confirmed, accentColors]; Слаткаристика [confirmed, accentColors]; Slavco Kocev [confirmed, accentColors]; Славе Димитров [confirmed, accentColors]; Smoke Shakers [confirmed, accentColors]; Смут [confirmed, accentColors]; Soulmental [confirmed, accentColors]; Sound Waves [confirmed, accentColors]; Sound_00 [confirmed, accentColors]; Spank [confirmed, accentColors]; SPECTRAL NERVE [confirmed, accentColors]; Steel Temple [confirmed, accentColors]; Steel Thunder [confirmed, accentColors]; Stefan Petanovski [confirmed, accentColors]; Стих Наумов [confirmed, accentColors]; Стиховен Калибар [confirmed, accentColors]; Стој, После! [confirmed, accentColors]; Страјк [confirmed, accentColors]; String Forces [confirmed, accentColors]; Студени Нозе [confirmed, accentColors]; Suns [confirmed, accentColors]; Sunset Cruise [confirmed, accentColors]; Супер Нова [confirmed, accentColors]; Суперхикс [confirmed, accentColors]; Svirci Vardarci [confirmed, accentColors]; Sweet Rapscalions [confirmed, accentColors]; Syned Brain [confirmed, accentColors]; Т.Б. Трачери [confirmed, accentColors]; TA$AK [confirmed, accentColors]; Тамара Стојковска [confirmed, accentColors]; Тамара Тодевска [confirmed, accentColors]; Тања Царовска [confirmed, accentColors]; Таско [confirmed, accentColors]; Taxi Consilium [confirmed, accentColors]; Телемама [confirmed, accentColors]; Тело Наука Совршена [confirmed, accentColors]; Темпера [confirmed, accentColors]; The Government [confirmed, accentColors]; The Hip [confirmed, accentColors]; The Hounds [confirmed, accentColors]; The John [confirmed, accentColors]; The Ooz [confirmed, accentColors]; The Protagonist [confirmed, accentColors]; The Wise Shouldn't Stay Quiet [confirmed, accentColors]; This Home Is Prepared [confirmed, accentColors]; this would save us [confirmed, accentColors]; Three Minutes in the Rain [confirmed, accentColors]; Toni Dimitrov [confirmed, accentColors]; Тони Китановски [confirmed, accentColors]; Тони Зен [confirmed, accentColors]; Тонио Сан [confirmed, accentColors]; Tonyo San [confirmed, accentColors]; Тоше Проески [confirmed, accentColors]; Trapostol [confirmed, accentColors]; Trendkill [confirmed, accentColors]; Трето Колено [confirmed, accentColors]; Трипнотик [confirmed, accentColors]; Trold [confirmed, accentColors]; Tsar Von Time [confirmed, accentColors]; Two Sides [confirmed, accentColors]; Überzeitung [confirmed, accentColors]; Убиј Дедо [confirmed, accentColors]; Угро [confirmed, accentColors]; Vagina Corporation [confirmed, accentColors]; Вански [confirmed, accentColors]; Vehementor [confirmed, accentColors]; ВЕЛ [confirmed, accentColors]; Венко Серафимов [confirmed, accentColors]; Верица Пандиловска [confirmed, accentColors]; Верка [confirmed, accentColors]; Викторија Лоба [confirmed, accentColors]; Визија [confirmed, accentColors]; Владо Јаневски [confirmed, accentColors]; Влатко Стефановски [confirmed, accentColors]; Водолија [confirmed, accentColors]; Врчак [confirmed, accentColors]; Warm Hands [confirmed, accentColors]; Will Discuss [confirmed, accentColors]; Xajka [confirmed, accentColors]; XARAKIRI [confirmed, accentColors]; Xavier Acid [confirmed, accentColors]; XXL [confirmed, accentColors]; Yordan Kostov [confirmed, accentColors]; Young Dadi [confirmed, accentColors]; Yudhisthira [confirmed, accentColors]; Зад Аголот [confirmed, accentColors]; Zanadu [confirmed, accentColors]; Зарина Првасевда [confirmed, accentColors]; ZEE [confirmed, accentColors]; Zhabata [confirmed, accentColors]; Животни [confirmed, accentColors]; Зијан [confirmed, accentColors]; Zol Jad [confirmed, accentColors]

Автоматски генерирано од MMM формуларот.$
Поднесено од: јас