### PR TITLE
MMM: Предлог промени

### DIFF
--- a/events.json
+++ b/events.json
@@ -72,7 +72,7 @@
       "title": "Дупер во Охрид LIVE Concert",
       "date": "2026-03-21",
       "time": "21:00",
-      "place": "Art Terrazza, Коста Абрас бр. 30, Охрид",
+      "place": "Art Terrazza, Охрид",
       "artists": [
         "Дупер"
       ],


### PR DESCRIPTION
Уреден настан: Дупер во Охрид LIVE Concert (2026-03-21)
Место: Art Terrazza, Охрид
Артисти: Дупер

Автоматски генерирано од MMM формуларот.