### PR TITLE
MMM: Предлог промени

### DIFF
--- a/events.json
+++ b/events.json
@@ -133,6 +133,28 @@
       "link": "https://kupikarta.com/event-details.nspx?eventid=5714"
     },
     {
+      "id": "evt-20260307-милко-последен-ден-ep-промо-концерт-mjsl",
+      "title": "Милко - Последен Ден EP >> Промо концерт",
+      "date": "2026-03-07",
+      "time": "21:00",
+      "place": "Македонски Паб Ѕе",
+      "artists": [
+        "Millko"
+      ],
+      "tickets": [
+        {
+          "label": "Билет",
+          "price": "200"
+        }
+      ],
+      "links": [
+        {
+          "label": "",
+          "url": "https://www.facebook.com/events/1853337125306391"
+        }
+      ]
+    },
+    {
       "id": "duper-oh-210326",
       "title": "Дупер во Охрид LIVE Concert",
       "date": "2026-03-21",


### PR DESCRIPTION
Предлог промени од MMM

Нови настани (19): Re:Start Festival: Ден 1 (2026-02-06), Re:Start Festival: Ден 2 (2026-02-07), ЛАКРИМАРИУМ - Концертна промоција на албумот (2026-02-20), Дупер во Штип LIVE Concert (2026-02-21), AFTERPARTY СО 2BONA (2026-02-21), My Tear и Side Quest (2026-02-28), Лозано - Километри Љубов (2026-03-07), Милко - Последен Ден EP >> Промо концерт (2026-03-07), Дупер во Охрид LIVE Concert (2026-03-21), Conquering Lion: One World (2026-03-21), Љубојна - 25 Години (2026-03-29), Јован Јованов, Елвир Мекиќ и пријателите (2026-06-06), Д ФЕСТ - Ден 1 (2026-06-26), Д ФЕСТ - Ден 2 (2026-06-27), Д ФЕСТ - Ден 3 (2026-06-28), 2bona (2026-07-26), SLATKARISTIKA & Friends (2026-08-02), Дупер (2026-08-05), NEXT TIME (2026-11-27)
Додадени артисти (1): Millko

Автоматски генерирано од MMM формуларот.