### PR TITLE
MMM: Предлог промени

### DIFF
--- a/bands.json
+++ b/bands.json
@@ -4072,6 +4072,21 @@
       "confirmed": false
     },
     {
+      "name": "Millko",
+      "city": "Скопје",
+      "genre": "Алтернативен Рок, Инди",
+      "soundsLike": "недостигаат податоци",
+      "links": {
+        "youtube": "https://www.youtube.com/watch?v=xkYi_gZghsI",
+        "spotify": "https://open.spotify.com/artist/7nGNq9uFLfNaTitHCQ7jDL?si=hYre72M6Q0eKXaucery30g",
+        "instagram": "https://www.instagram.com/millkomkd/"
+      },
+      "contact": "недостигаат податоци",
+      "label": null,
+      "accentColors": null,
+      "confirmed": false
+    },
+    {
       "name": "Mindless Violence",
       "city": "Скопје",
       "genre": "Хардкор, Панк",


### PR DESCRIPTION
Предлог промени од MMM

Нови настани (19): Re:Start Festival: Ден 1 (2026-02-06), Re:Start Festival: Ден 2 (2026-02-07), ЛАКРИМАРИУМ - Концертна промоција на албумот (2026-02-20), Дупер во Штип LIVE Concert (2026-02-21), AFTERPARTY СО 2BONA (2026-02-21), My Tear и Side Quest (2026-02-28), Лозано - Километри Љубов (2026-03-07), Милко - Последен Ден EP >> Промо концерт (2026-03-07), Дупер во Охрид LIVE Concert (2026-03-21), Conquering Lion: One World (2026-03-21), Љубојна - 25 Години (2026-03-29), Јован Јованов, Елвир Мекиќ и пријателите (2026-06-06), Д ФЕСТ - Ден 1 (2026-06-26), Д ФЕСТ - Ден 2 (2026-06-27), Д ФЕСТ - Ден 3 (2026-06-28), 2bona (2026-07-26), SLATKARISTIKA & Friends (2026-08-02), Дупер (2026-08-05), NEXT TIME (2026-11-27)
Додадени артисти (1): Millko

Автоматски генерирано од MMM формуларот.